### PR TITLE
이펙티브 자바 아이템4 학습

### DIFF
--- a/programming-language/java/project/ex/src/effectiveJava/chapter01/item04/UtilityClass.java
+++ b/programming-language/java/project/ex/src/effectiveJava/chapter01/item04/UtilityClass.java
@@ -1,0 +1,14 @@
+package effectiveJava.chapter01.item04;
+
+public class UtilityClass {
+
+    private UtilityClass() {
+        throw new AssertionError();
+    }
+
+    public static int multiplication(int x) {
+        return x * x;
+    }
+
+
+}

--- a/programming-language/java/project/ex/src/effectiveJava/chapter01/item04/UtilityDriver.java
+++ b/programming-language/java/project/ex/src/effectiveJava/chapter01/item04/UtilityDriver.java
@@ -1,0 +1,9 @@
+package effectiveJava.chapter01.item04;
+
+public class UtilityDriver {
+
+    public static void main(String[] args) {
+        System.out.println(UtilityClass.multiplication(2));
+
+    }
+}


### PR DESCRIPTION
인스턴스화를 막으려거든 private 생성자 사용
- 고정된 메모리 영역을 얻기 때문에 메모리 낭비 x 
- 인스턴스를 생성하지 않아도 이미 메모리에 올라가있는 상태로 사용