### PR TITLE
이펙티브 자바 아이템5 자원을 직접 명시하지 말고 의존 객체 주입을 사용하라 

### DIFF
--- a/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/Lexicon.java
+++ b/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/Lexicon.java
@@ -1,0 +1,4 @@
+package effectiveJava.chapter01.item05;
+
+public class Lexicon {
+}

--- a/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpecialVocabularyLexicon.java
+++ b/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpecialVocabularyLexicon.java
@@ -1,4 +1,4 @@
 package effectiveJava.chapter01.item05;
 
-public class SpecialVocabularyLexicon {
+public class SpecialVocabularyLexicon extends Lexicon{
 }

--- a/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpecialVocabularyLexicon.java
+++ b/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpecialVocabularyLexicon.java
@@ -1,0 +1,4 @@
+package effectiveJava.chapter01.item05;
+
+public class SpecialVocabularyLexicon {
+}

--- a/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpellCheckerDriver.java
+++ b/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpellCheckerDriver.java
@@ -1,0 +1,18 @@
+package effectiveJava.chapter01.item05;
+
+public class SpellCheckerDriver {
+
+    public static void main(String[] args) {
+
+        //정적 유틸리와 싱글턴은 특수 어학용 사전으로 바꾸려면...
+        SpellCheckerEx1.isValid("단어");
+        SpellCheckerEx2.INSTANCE.isValid("단어");
+        
+        //테스트 사전
+        SpellCheckerEx3 spellChecker = new SpellCheckerEx3(new TestLexicon());
+
+        //특수 어학용 사전
+        SpellCheckerEx3 spellChecker2 = new SpellCheckerEx3(new SpecialVocabularyLexicon());
+    }
+
+}

--- a/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpellCheckerEx1.java
+++ b/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpellCheckerEx1.java
@@ -1,0 +1,22 @@
+package effectiveJava.chapter01.item05;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SpellCheckerEx1 {
+    private static final Lexicon dictionary = new TestLexicon();
+
+    //객체 생성 방지
+    private SpellCheckerEx1() {}
+
+    public static boolean isValid(String word) {
+        return false;
+    }
+    public static List<String> suggestions(String typo) {
+        List<String> result = new ArrayList<>();
+        //맞춤법 검사 생략
+        result.add(typo);
+        return result;
+    }
+
+}

--- a/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpellCheckerEx2.java
+++ b/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpellCheckerEx2.java
@@ -1,0 +1,24 @@
+package effectiveJava.chapter01.item05;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SpellCheckerEx2 {
+
+    private final Lexicon dictionary = new TestLexicon();
+
+    //객체 생성 방지
+    private SpellCheckerEx2() {}
+    public static SpellCheckerEx2 INSTANCE = new SpellCheckerEx2();
+
+    public static boolean isValid(String word) {
+        return false;
+    }
+    public static List<String> suggestions(String typo) {
+        List<String> result = new ArrayList<>();
+        //맞춤법 검사 생략
+        result.add(typo);
+        return result;
+    }
+
+}

--- a/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpellCheckerEx3.java
+++ b/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/SpellCheckerEx3.java
@@ -1,0 +1,25 @@
+package effectiveJava.chapter01.item05;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class SpellCheckerEx3 {
+
+    private final Lexicon dictionary;
+
+    public SpellCheckerEx3(Lexicon dictionary) {
+        this.dictionary = Objects.requireNonNull(dictionary);
+    }
+
+    public static boolean isValid(String word) {
+        return false;
+    }
+    public static List<String> suggestions(String typo) {
+        List<String> result = new ArrayList<>();
+        //맞춤법 검사 생략
+        result.add(typo);
+        return result;
+    }
+
+}

--- a/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/TestLexicon.java
+++ b/programming-language/java/project/ex/src/effectiveJava/chapter01/item05/TestLexicon.java
@@ -1,0 +1,4 @@
+package effectiveJava.chapter01.item05;
+
+public class TestLexicon extends Lexicon{
+}


### PR DESCRIPTION
사용하는 자원에 따라 동작이 달라지는 클래스에는
정적 유틸리티 클래스나 싱글턴 방식이 적합하지 않는다

의존 객체 주입으로 바꿔서 유연성과 테스트를 높여줘야한다
(OCP/DIP 원칙을 따르기)