### PR TITLE
Feat Email 목록을 콤마로 구분해서 저장 하기 위해 밸류 컬렉션 매핑

### DIFF
--- a/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/common/jpa/EmailSetConverter.java
+++ b/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/common/jpa/EmailSetConverter.java
@@ -1,0 +1,32 @@
+package com.ddd.ex.common.jpa;
+
+import com.ddd.ex.common.model.Email;
+import com.ddd.ex.common.model.EmailSet;
+
+import javax.persistence.AttributeConverter;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toSet;
+
+public class EmailSetConverter implements AttributeConverter<EmailSet, String> {
+    @Override
+    public String convertToDatabaseColumn(EmailSet attribute) {
+        if (attribute == null) return  null;
+        return attribute.getEmails().stream()
+                .map(email -> email.getAddress())
+                .collect(Collectors.joining(","));
+    }
+
+    @Override
+    public EmailSet convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        String[] emails = dbData.split(",");
+        Set<Email> emailSet = Arrays.stream(emails)
+                .map(value -> Email.of(value))
+                .collect(toSet());
+
+        return EmailSet.of(emailSet);
+    }
+}

--- a/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/common/model/Email.java
+++ b/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/common/model/Email.java
@@ -1,0 +1,36 @@
+package com.ddd.ex.common.model;
+
+import java.util.Objects;
+
+public class Email {
+
+    private String address;
+
+    protected Email() {
+
+    }
+
+    private Email(String address) {
+        this.address = address;
+    }
+
+    public static Email of(String address) {
+        return new Email(address);
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Email email)) return false;
+        return address != null && address.equals(email.address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address);
+    }
+}

--- a/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/common/model/EmailSet.java
+++ b/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/common/model/EmailSet.java
@@ -1,0 +1,29 @@
+package com.ddd.ex.common.model;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class EmailSet {
+
+    private Set<Email> emails = new HashSet<>();
+
+    protected EmailSet() {
+
+    }
+
+    private EmailSet(Set<Email> emails) {
+        this.emails = emails;
+    }
+
+    public static EmailSet of(Set<Email> emails) {
+        return new EmailSet(emails);
+    }
+
+    public Set<Email> getEmails() {
+        /**
+         * 이메일 주소 목록을 수정 할 수 없는 "읽기 전용"보기로 반환
+         */
+        return Collections.unmodifiableSet(emails);
+    }
+}


### PR DESCRIPTION
Workflow
1. Email 정의
2. EmailSet 정의
- `getEmails`메서드 반환값을
이메일 주소 목록을 수정 할 수 없도록 `읽기 전용`으로 반환
3. EmailSetConverter 정의
`AttributeConverter`를 사용하여 밸류 컬렉션을 한 개 컬럼에 쉽게 매핑