### PR TITLE
Image밸류 컬렉션을 @Entity로 매핑하고 Product에 의존  

### DIFF
--- a/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/product/domain/ExternalImage.java
+++ b/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/product/domain/ExternalImage.java
@@ -1,0 +1,28 @@
+package com.ddd.ex.product.domain;
+
+public class ExternalImage extends Image{
+
+    protected ExternalImage() {
+
+    }
+
+    public ExternalImage(String path) {
+        super(path);
+    }
+
+    @Override
+    public String getUrl() {
+        return getPath();
+    }
+
+    @Override
+    public boolean hasThumbnail() {
+        return false;
+    }
+
+    @Override
+    public String getThumbnailUrl() {
+        // TODO: 경로 정해지면 수정
+        return null;
+    }
+}

--- a/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/product/domain/Image.java
+++ b/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/product/domain/Image.java
@@ -1,0 +1,45 @@
+package com.ddd.ex.product.domain;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "image_type")
+@Table(name = "image")
+public abstract class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @Column(name = "image_path")
+    private String path;
+
+    @Column(name = "upload_time")
+    private LocalDateTime uploadTime;
+
+    protected Image() {
+    }
+
+    public Image(String path) {
+        this.path = path;
+        this.uploadTime = LocalDateTime.now();
+    }
+
+    protected String getPath() {
+        return path;
+    }
+
+    public LocalDateTime getUploadTime() {
+        return uploadTime;
+    }
+
+    public abstract String getUrl();
+
+    public abstract boolean hasThumbnail();
+
+    public abstract String getThumbnailUrl();
+
+}

--- a/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/product/domain/InternalImage.java
+++ b/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/product/domain/InternalImage.java
@@ -1,0 +1,32 @@
+package com.ddd.ex.product.domain;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("II")
+public class InternalImage extends Image{
+
+    protected InternalImage() {
+    }
+
+    public InternalImage(String path) {
+        super(path);
+    }
+
+    @Override
+    public String getUrl() {
+        return "/images/original"+getPath();
+    }
+
+    @Override
+    public boolean hasThumbnail() {
+        return true;
+    }
+
+    @Override
+    public String getThumbnailUrl() {
+        // TODO: 경로 정해지면 수정
+        return null;
+    }
+}

--- a/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/product/domain/Product.java
+++ b/books/도메인-주도-개발-시작하기/ex/src/main/java/com/ddd/ex/product/domain/Product.java
@@ -1,0 +1,73 @@
+package com.ddd.ex.product.domain;
+
+import com.ddd.ex.common.jpa.MoneyConverter;
+import com.ddd.ex.common.model.Money;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Entity
+@Table(name = "product")
+public class Product {
+
+    @EmbeddedId
+    private ProductId id;
+
+    private String name;
+
+    @Convert(converter = MoneyConverter.class)
+    private Money price;
+
+    private String detail;
+
+    @OneToMany(
+            cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+            orphanRemoval = true
+    )
+    @JoinColumn(name = "product_id")
+    @OrderColumn(name = "list_idx")
+    private List<Image> images = new ArrayList<>();
+
+    protected Product() {
+    }
+
+    private Product(ProductId id, String name, Money price, String detail, List<Image> images) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.detail = detail;
+        this.images = images;
+    }
+
+    public static Product of(ProductId id, String name, Money price, String detail, List<Image> images) {
+        return new Product(id, name, price, detail, images);
+    }
+
+    public ProductId getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Money getPrice() {
+        return price;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public List<Image> getImages() {
+        return Collections.unmodifiableList(images);
+    }
+
+    public void changeImages(List<Image> newImages) {
+        images.clear();
+        images.addAll(newImages);
+    }
+
+}


### PR DESCRIPTION
제품의 이미지 업로드 방식에 따라
이미지 경로와 섬네일 이미지 제공 여부가 달라진다 
`JPA`의 `@Embeddable`타입의 클래스 상속 매핑을 지원하지 않는다

이번 기능은 이미지 업로드 방식에 따라 경로와 섬네일 이미지 제공 여부가 달라지기 때문에
상속을 통해 여러 타입의 객체를 하나의 타입으로 관리할 수 있도록
`@Entity`를 이용해서 상속 매핑으로 처리한다. 

다만 하이버네이트의 경우 `@Entity`를 위한 컬렉션 객체의 clear() 메서드를 호출하면 각 개별 엔티티에 대해 delete쿼리를 실행한다.
변경 빈도가 낮으면 괜찮지만 빈도가 높으면 전체 서비스 성능에 문제가 된다

만일 서비스 성능에 문제가 발생한다면 
`@Embeddable`타입에 대한 컬렉션의 clear()메서드를 호출하면
컬렉션에 속한 객체를 로딩하지 않고 한 번의 delete쿼리로 삭제 처리할 수 있기 때문에 
상속으로 구현하는 것보다 성능이 좋다 